### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/DiachenkoG/2948f651-f8ca-4be2-9dfe-13022de0813c/26aa87ff-cfea-491a-b6cc-5d9229cdd360/_apis/work/boardbadge/42363677-e520-49b7-a507-eaeccdc9e12d)](https://dev.azure.com/DiachenkoG/2948f651-f8ca-4be2-9dfe-13022de0813c/_boards/board/t/26aa87ff-cfea-491a-b6cc-5d9229cdd360/Microsoft.RequirementCategory)
 # main


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#7](https://dev.azure.com/DiachenkoG/2948f651-f8ca-4be2-9dfe-13022de0813c/_workitems/edit/7). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.